### PR TITLE
fix: no longer printing outputsccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc 

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -71,7 +71,7 @@ jobs:
         curl -u ${{ github.actor }}:${{ secrets.PAT }} -X PUT \
         -H "Accept: application/vnd.github.v3+json" \
         https://api.github.com/repos/${{ github.repository }}/pulls/${{ fromJson(steps.create_pr_step.outputs.response).number }}/merge
-    - name: check response output
-      run: |
-        echo ${{ fromJson(steps.create_pr_step.outputs.response).number }}
-        echo ${{ github.event.head_commit.message }}
+    # - name: check response output
+      # run: |
+        # echo ${{ fromJson(steps.create_pr_step.outputs.response).number }}
+        # echo ${{ github.event.head_commit.message }}


### PR DESCRIPTION
Printing commit message would sometimes break workflow since if there was a second line it would treat the second line as a command, thus breaking it. Print/echo statements are now commented out